### PR TITLE
Small improvements and fixes

### DIFF
--- a/examples/myapp/pipeline_params.py
+++ b/examples/myapp/pipeline_params.py
@@ -18,7 +18,7 @@ from .params import Serve
 from .params import Train
 
 
-@tunable("hidden_units", "dropout", apps=("train",))
+@tunable("hidden_units", "dropout", apps="train")
 @tunable("batch_norm", apps="train")
 @tunable("root_param", apps=("train"))
 def build_model(
@@ -29,11 +29,18 @@ def build_model(
     return "model"
 
 
-@tunable("epochs", "batch_size", apps=("train",))
+@tunable("epochs", "batch_size", apps="train")
 @tunable("optimizer", namespace="train", apps="train")
 def train(epochs=Train.epochs, batch_size=Train.batch_size, optimizer: Literal["adam", "sgd"] = "adam"):
     """Train the model using centralized parameters."""
     print("train", epochs, batch_size, optimizer)
+
+
+@tunable("nb_epochs", "other_batch_size", apps="train")
+@tunable("optimizer", namespace="train", apps="train")
+def other_train(nb_epochs=Train.epochs, other_batch_size=Train.batch_size, optimizer: Literal["adam", "sgd"] = "adam"):
+    """Train the model using centralized parameters with other argument names than the reference ones."""
+    print("other_train", nb_epochs, other_batch_size, optimizer)
 
 
 @tunable("dropna", "normalize", "clip_outliers", apps=("train", "serve"))
@@ -45,7 +52,7 @@ def preprocess(
     return "clean"
 
 
-@tunable("port", "workers", apps=("serve",))
+@tunable("port", "workers", apps="serve")
 def serve_api(port=Serve.port, workers=Serve.workers):
     print("serve_api", port, workers)
 
@@ -55,6 +62,7 @@ def train_main():
     preprocess("/data/train.csv")
     build_model()
     train()
+    other_train()
 
 
 def serve_main():

--- a/src/tunablex/decorators.py
+++ b/src/tunablex/decorators.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import functools
 import inspect
+import re
 from typing import TYPE_CHECKING
 from typing import Any
 
@@ -23,6 +24,11 @@ if TYPE_CHECKING:
     from pydantic import BaseModel
 
 
+def _pascalcase_to_snake_case(ns: str) -> str:
+    """Convert a namespace name from PascalCase to snake_case."""
+    return re.sub(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])", "_", ns).lower()
+
+
 class TunableParamMeta(type):
     """A metaclass that allows to retrieve namespace and type annotation at runtime."""
 
@@ -30,9 +36,10 @@ class TunableParamMeta(type):
         parent = cls.mro()[1]
         if parent is object:
             return ""
+        ns = _pascalcase_to_snake_case(super().__getattribute__("__name__"))
         if parent._namespace():
-            return f"{parent._namespace()}.{super().__getattribute__('__name__').lower()}"
-        return super().__getattribute__("__name__").lower()
+            return f"{parent._namespace()}.{ns}"
+        return ns
 
     def __getattribute__(cls, name: str):
         if name.startswith("__"):

--- a/src/tunablex/decorators.py
+++ b/src/tunablex/decorators.py
@@ -70,7 +70,7 @@ def tunable(
     - apps: optional tags to group functions per executable/app.
     """
     include_set = set(include or ())
-    exclude_set = set(exclude)
+    exclude_set = {exclude} if isinstance(exclude, str) else set(exclude)
     if include_set and exclude_set:
         msg = "Cannot pass both `include` and `exclude` arguments."
         raise ValueError(msg)

--- a/src/tunablex/decorators.py
+++ b/src/tunablex/decorators.py
@@ -118,7 +118,7 @@ def tunable(
             ns_dict.update({name: (typ, default)})
 
         for ns, fields in namespaces.items():
-            REGISTRY.register(TunableEntry(fn=fn, fields=fields, sig=sig, namespace=ns, apps=set(apps)))
+            REGISTRY.register(TunableEntry(fn=fn, fields=fields, namespace=ns, apps=set(apps)))
 
         @functools.wraps(fn)
         def wrapper(*args, cfg: BaseModel | dict | None = None, **kwargs):

--- a/src/tunablex/registry.py
+++ b/src/tunablex/registry.py
@@ -18,21 +18,19 @@ from pydantic import Field
 from pydantic import ValidationError
 from pydantic import create_model
 
-if TYPE_CHECKING:  # typing-only imports
-    import inspect
+if TYPE_CHECKING:
     from collections.abc import Iterable
 
 
 @dataclass
 class TunableEntry:
-    """A registered tunable function and its Pydantic model."""
+    """A registered tunable function and its default fields."""
 
     fields: dict[str, tuple[str, Field | Any]]
     """The fields of the model.
     The keys are the parameters names, and the items are the type (as a string) and the Field or the default value."""
 
     fn: Any
-    sig: inspect.Signature
     namespace: str
     apps: set[str] = field(default_factory=set)
 

--- a/src/tunablex/runtime.py
+++ b/src/tunablex/runtime.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import yaml
 from pydantic import BaseModel
 from pydantic import ValidationError
 
@@ -99,6 +100,8 @@ def write_schema(prefix: str, schema: dict, defaults: dict | None = None):
     Path(f"{prefix}.schema.json").write_text(json.dumps(schema, indent=2, default=str))
     if defaults is not None:
         Path(f"{prefix}.json").write_text(json.dumps(defaults, indent=2, default=str))
+        with Path(f"{prefix}.yml").open("w") as f:
+            yaml.dump(defaults, f, default_flow_style=False)
 
 
 def make_app_config_for(app: str) -> BaseModel:

--- a/src/tunablex/runtime.py
+++ b/src/tunablex/runtime.py
@@ -101,7 +101,7 @@ def write_schema(prefix: str, schema: dict, defaults: dict | None = None):
     if defaults is not None:
         Path(f"{prefix}.json").write_text(json.dumps(defaults, indent=2, default=str))
         with Path(f"{prefix}.yml").open("w") as f:
-            yaml.dump(defaults, f, default_flow_style=False)
+            yaml.dump(defaults, f, default_flow_style=False, sort_keys=False)
 
 
 def make_app_config_for(app: str) -> BaseModel:

--- a/tests/test_centralized_params.py
+++ b/tests/test_centralized_params.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
 import pytest
 
@@ -51,3 +50,28 @@ def test_file_plus_overrides_with_centralized_params(tmp_path, run_example):
     assert code == 0, err
     assert "build_model 512 0.25 False newRoot" in out
     assert "train 50 8 sgd" in out
+
+
+@pytest.mark.skipif(pytest.importorskip("jsonargparse") is None, reason="jsonargparse not installed")
+def test_other_argnames_from_centralized_params(tmp_path, run_example):
+    cfg = tmp_path / "train_config.json"
+    cfg.write_text(
+        json.dumps({
+            "batch_norm": False,
+            "root_param": "newRoot",
+            "model": {
+                "dropout": 0.15,
+                "hidden_units": 256,
+                "preprocess": {"dropna": False, "normalize": "minmax", "clip_outliers": 2.5},
+            },
+            "train": {"epochs": 5, "batch_size": 8, "optimizer": "sgd"},
+        })
+    )
+    code, out, err = run_example(
+        "examples/jsonargparse_app/train_jsonarg_params.py",
+        ["--config", str(cfg)],
+    )
+    assert code == 0, err
+    assert "build_model 256 0.15 False newRoot" in out
+    assert "train 5 8 sgd" in out
+    assert "other_train 5 8 sgd" in out


### PR DESCRIPTION
Features :
- convert the names of namespaces defined with TunableParam metaclass to snake_case
- add yaml dump for default params
- allow local argnames in functions to differ from their global TunableParam definition + add corresponding test

Fix : bug when excluding a single param in `@tunable` if the param is not passed as a 1-uple

Misc: delete unused arguments and class attributes