### PR TITLE
misc: remove unneeded methods from API

### DIFF
--- a/src/tunablex/__init__.py
+++ b/src/tunablex/__init__.py
@@ -5,9 +5,7 @@ from .cli_helpers import add_flags_by_entry as add_flags_by_entry
 from .cli_helpers import build_cfg_from_file_and_args as build_cfg_from_file_and_args
 from .context import use_config as use_config
 from .decorators import TunableParams as TunableParams
-from .decorators import TunableParamsMeta as TunableParamsMeta
 from .decorators import tunable as tunable
-from .registry import REGISTRY as REGISTRY
 from .runtime import load_config_for_app as load_config_for_app
 from .runtime import load_config_for_entry as load_config_for_entry
 from .runtime import make_config_for_app as make_config_for_app

--- a/tests/test_lazy_type_hints.py
+++ b/tests/test_lazy_type_hints.py
@@ -13,8 +13,8 @@ raise NameError. The lazy implementation should ignore 'b' and succeed.
 
 from __future__ import annotations
 
-from tunablex import REGISTRY
 from tunablex import tunable
+from tunablex.registry import REGISTRY
 
 
 # Use an explicit unique namespace to avoid interference with other tests.


### PR DESCRIPTION
Removed some methods from the API since they are only meant to be used inside the library