### PR TITLE
Use parameters docstring as Pydantic description

### DIFF
--- a/examples/app_generate_schema.py
+++ b/examples/app_generate_schema.py
@@ -11,6 +11,10 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).parents[1]))
 
 import examples.myapp.pipeline_params as pipeline_params
 

--- a/examples/myapp/params.py
+++ b/examples/myapp/params.py
@@ -30,7 +30,8 @@ class PreprocessParams(TunableParams):
 
     dropna: bool = Field(True, description="Drop rows with missing values")
     normalize: Literal["zscore", "minmax", "none"] = Field("zscore", description="Normalization strategy")
-    clip_outliers: float = Field(3.0, ge=0, le=10, description="Clip values beyond k standard deviations")
+    clip_outliers: float = Field(3.0, ge=0, le=10)
+    """Clip values beyond k standard deviations. Description in docstring."""
 
 
 class ModelParams(TunableParams):

--- a/examples/myapp/params.py
+++ b/examples/myapp/params.py
@@ -19,7 +19,11 @@ from tunablex import TunableParams
 class MainParams(TunableParams):
     """Root for centralized tunable namespaces ("main")."""
 
-    root_param: str = Field("default", description="A root-level parameter")
+    root_param: str = Field("root", description="A root-level parameter")
+
+    class Advanced(TunableParams):  # noqa: D106
+        advanced_root_param: str = Field(default="advanced_root")
+        """Advanced root parameter."""
 
 
 class PreprocessParams(TunableParams):

--- a/examples/myapp/pipeline_params.py
+++ b/examples/myapp/pipeline_params.py
@@ -21,18 +21,17 @@ from .pipeline_submodule import submodule_fun
 Preprocess = ModelParams.Preprocess
 
 
-@tunable("hidden_units", "dropout", "agg", apps="train")
-@tunable("batch_norm", apps="train")
-@tunable("root_param", apps="train")
+@tunable(apps="train")
 def build_model(
     hidden_units=ModelParams.hidden_sizes,
     dropout=ModelParams.dropout,
     agg=ModelParams.agg,
     batch_norm: bool = True,
     root_param=MainParams.root_param,
+    advanced_root_param=MainParams.Advanced.advanced_root_param,
 ):
     """Build the model using centralized parameters."""
-    print("build_model", hidden_units, dropout, agg, batch_norm, root_param)
+    print("build_model", hidden_units, dropout, agg, batch_norm, root_param, advanced_root_param)
     return "model"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
   { name = "Jacques Papper" },
   { name = "Vincent Drouet", email = "v.drouet@iconcfd.com" }
 ]
-dependencies = ["pydantic>=2.4"]
+dependencies = ["pydantic>=2.12.5"]
 classifiers = [
   "Development Status :: 3 - Alpha",
   "License :: OSI Approved :: MIT License",

--- a/src/tunablex/__init__.py
+++ b/src/tunablex/__init__.py
@@ -5,9 +5,7 @@ from .cli_helpers import add_flags_by_entry as add_flags_by_entry
 from .cli_helpers import build_cfg_from_file_and_args as build_cfg_from_file_and_args
 from .context import use_config as use_config
 from .decorators import TunableParams as TunableParams
-from .decorators import TunableParamsMeta as TunableParamsMeta
 from .decorators import tunable as tunable
-from .registry import REGISTRY as REGISTRY
 from .runtime import load_config_for_app as load_config_for_app
 from .runtime import load_config_for_entry as load_config_for_entry
 from .runtime import make_config_for_app as make_config_for_app

--- a/src/tunablex/decorators.py
+++ b/src/tunablex/decorators.py
@@ -99,6 +99,9 @@ class TunableParams(metaclass=TunableParamsMeta):
     When using several levels of namespaces, it is possible to declare the parameters in a class at the root level
     and to reference this class in the namespace, to avoid having too many indentations in the lower levels.
 
+    Docstrings enclosed in triple double-quotes will be used as parameter's description
+    if none is provided in the Field definition.
+
     Example:
         # This is root level
         class AdvancedParams(TunableParams):

--- a/src/tunablex/decorators.py
+++ b/src/tunablex/decorators.py
@@ -10,7 +10,7 @@ import functools
 import inspect
 import re
 import sys
-from contextlib import suppress
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import get_type_hints
@@ -32,7 +32,7 @@ def _pascalcase_to_snake_case(ns: str) -> str:
     return re.sub(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])", "_", ns).lower()
 
 
-def _get_description(cls: type, name: str) -> str:
+def _get_description(cls: type, name: str) -> str | None:
     """Get a parameter's description from its docstring.
 
     Args:
@@ -40,15 +40,28 @@ def _get_description(cls: type, name: str) -> str:
         name: Parameter's name
 
     Returns:
-        Parameter's docstring.
+        Parameter's docstring, or None if it does not exist.
     """
-    source = inspect.getsource(cls)
-    i1 = source.index(name)
-    s1 = source[i1:]
-    i2 = s1.index('"""') + 3
-    s2 = s1[i2:]
-    i3 = s2.index('"""')
-    return s2[:i3]
+    try:
+        source = inspect.getsource(cls)
+        i1 = source.index(name)
+        s1 = source[i1:]
+        i2 = s1.index('"""') + 3
+        s2 = s1[i2:]
+        i3 = s2.index('"""')
+        return s2[:i3]
+    except Exception:  # noqa: BLE001
+        return None
+
+
+@dataclass
+class TunableParamData:
+    """Class containing the data of a tunable parameter."""
+
+    value: Any
+    typ: type
+    namespace: str
+    name: str
 
 
 class TunableParamsMeta(type):
@@ -78,14 +91,6 @@ class TunableParamsMeta(type):
         if super().__getattribute__("namespace") is None:
             cls.namespace = TunableParamsMeta._process_name(super().__getattribute__("__name__"))
 
-        if isinstance(value := super().__getattribute__(name), FieldInfo):
-            globalsns = vars(sys.modules[cls.__module__])
-            typ = get_type_hints(cls, globalns=globalsns).get(name, Any)
-            if value.description is None:
-                with suppress(Exception):
-                    value.description = _get_description(cls, name)
-            return value, typ, cls.namespace, name
-
         # If value is a class with this metaclass, update its parent namespace
         if isinstance(value, type) and isinstance(value, TunableParamsMeta):
             value.namespace = (
@@ -93,6 +98,14 @@ class TunableParamsMeta(type):
                 if cls.namespace
                 else TunableParamsMeta._process_name(name)  # for cases like main.advanced
             )
+            return value
+
+        if isinstance(value, FieldInfo):
+            globalsns = vars(sys.modules[cls.__module__])
+            typ = get_type_hints(cls, globalns=globalsns).get(name, Any)
+            if value.description is None:
+                value.description = _get_description(cls, name)
+            return TunableParamData(value, typ, cls.namespace, name)
 
         return value
 
@@ -173,9 +186,14 @@ def tunable(
             if not selected:
                 continue
             default = p.default if p.default is not inspect._empty else ...
-            if isinstance(default, tuple) and isinstance(default[0], FieldInfo):
+            if isinstance(default, TunableParamData):
                 # The parameter is declared in a TunableParam class; retrieve type, namespace and reference name
-                default, typ, ns, ref_name = default
+                default, typ, ns, ref_name = (
+                    default.value,
+                    default.typ,
+                    default.namespace,
+                    default.name,
+                )
                 if ref_name != name:
                     # Store the reference name for later look-up
                     # This allows to have different local names for the same global parameter

--- a/src/tunablex/decorators.py
+++ b/src/tunablex/decorators.py
@@ -71,6 +71,10 @@ class TunableParamsMeta(type):
 
         Store the classes that are accessed and use them to build the final namespace.
         """
+        value = super().__getattribute__(name)
+        if not isinstance(cls, TunableParamsMeta):
+            return value
+
         if super().__getattribute__("namespace") is None:
             cls.namespace = TunableParamsMeta._process_name(super().__getattribute__("__name__"))
 
@@ -84,7 +88,11 @@ class TunableParamsMeta(type):
 
         # If value is a class with this metaclass, update its parent namespace
         if isinstance(value, type) and isinstance(value, TunableParamsMeta):
-            value.namespace = f"{cls.namespace}.{TunableParamsMeta._process_name(name)}"
+            value.namespace = (
+                f"{cls.namespace}.{TunableParamsMeta._process_name(name)}"
+                if cls.namespace
+                else TunableParamsMeta._process_name(name)  # for cases like main.advanced
+            )
 
         return value
 

--- a/src/tunablex/decorators.py
+++ b/src/tunablex/decorators.py
@@ -10,6 +10,7 @@ import functools
 import inspect
 import re
 import sys
+from contextlib import suppress
 from typing import TYPE_CHECKING
 from typing import Any
 from typing import get_type_hints
@@ -29,6 +30,25 @@ if TYPE_CHECKING:
 def _pascalcase_to_snake_case(ns: str) -> str:
     """Convert a namespace name from PascalCase to snake_case."""
     return re.sub(r"(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])", "_", ns).lower()
+
+
+def _get_description(cls: type, name: str) -> str:
+    """Get a parameter's description from its docstring.
+
+    Args:
+        cls: TunableParams class containing the parameter.
+        name: Parameter's name
+
+    Returns:
+        Parameter's docstring.
+    """
+    source = inspect.getsource(cls)
+    i1 = source.index(name)
+    s1 = source[i1:]
+    i2 = s1.index('"""') + 3
+    s2 = s1[i2:]
+    i3 = s2.index('"""')
+    return s2[:i3]
 
 
 class TunableParamsMeta(type):
@@ -57,6 +77,9 @@ class TunableParamsMeta(type):
         if isinstance(value := super().__getattribute__(name), FieldInfo):
             globalsns = vars(sys.modules[cls.__module__])
             typ = get_type_hints(cls, globalns=globalsns).get(name, Any)
+            if value.description is None:
+                with suppress(Exception):
+                    value.description = _get_description(cls, name)
             return value, typ, cls.namespace, name
 
         # If value is a class with this metaclass, update its parent namespace

--- a/src/tunablex/decorators.py
+++ b/src/tunablex/decorators.py
@@ -148,7 +148,6 @@ def tunable(
 
     def decorator(fn):
         sig = inspect.signature(fn)
-        ns = namespace
         namespaces = set()
         ref_names = {}
         for name, p in sig.parameters.items():
@@ -177,6 +176,7 @@ def tunable(
             else:
                 typ = inspect.get_annotations(fn, eval_str=False)[name]
                 typ = eval(typ, fn.__globals__) if isinstance(typ, str) else typ
+                ns = namespace
             namespaces.add(ns)
             REGISTRY.register(
                 TunableArg(

--- a/src/tunablex/registry.py
+++ b/src/tunablex/registry.py
@@ -14,11 +14,13 @@ import sys
 from contextlib import suppress
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from typing import Annotated
 from typing import Any
 
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import create_model
+from pydantic.fields import FieldInfo
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -164,7 +166,12 @@ class TunableRegistry:
         fields = {}
         for name, entry in node.entries.items():
             if app in entry.apps or "ALL" in entry.apps:
-                fields[name] = (entry.typ, entry.default)
+                if isinstance(entry.default, FieldInfo):
+                    # Recreate the Field to merge the description, see https://docs.pydantic.dev/latest/examples/dynamic_models/
+                    default_dict = entry.default.asdict()
+                    fields[name] = Annotated[entry.typ, *default_dict["metadata"], Field(**default_dict["attributes"])]
+                else:
+                    fields[name] = (entry.typ, entry.default)
         for name, child in node.children.items():
             child_model = self.build_config_for_app(app, child)
             if child_model.model_fields:

--- a/tests/test_centralized_params.py
+++ b/tests/test_centralized_params.py
@@ -75,3 +75,17 @@ def test_other_argnames_from_centralized_params(tmp_path, run_example):
     assert "build_model [128, 128] 0.15 sum False newRoot" in out
     assert "train 5 8 sgd" in out
     assert "other_train 5 8 sgd" in out
+
+
+def test_get_description_from_docstring(tmp_path, run_example):
+    cfg_path = tmp_path / "test_config"
+    run_example(
+        "examples/app_generate_schema.py",
+        ["--prefix", str(cfg_path)],
+    )
+
+    schema_path = cfg_path.with_suffix(".schema.json")
+    with schema_path.open() as f:
+        cfg = json.load(f)
+    assert "clip_outliers" in str(cfg)
+    assert "Description in docstring." in str(cfg)

--- a/tests/test_centralized_params.py
+++ b/tests/test_centralized_params.py
@@ -12,7 +12,7 @@ def test_app_with_centralized_params_defaults_and_overrides(run_example):
         ["--train.epochs", "20", "--model.hidden_sizes", "128", "256", "--model.preprocess.normalize", "minmax"],
     )
     assert code == 0, err
-    assert "build_model [128, 256]" in out
+    assert "build_model [128, 256] 0.2 sum True root advanced_root" in out
     assert "train 20 32 adam" in out
 
 

--- a/tests/test_lazy_type_hints.py
+++ b/tests/test_lazy_type_hints.py
@@ -13,8 +13,8 @@ raise NameError. The lazy implementation should ignore 'b' and succeed.
 
 from __future__ import annotations
 
-from tunablex import REGISTRY
 from tunablex import tunable
+from tunablex.registry import REGISTRY
 
 
 # Use an explicit unique namespace to avoid interference with other tests.


### PR DESCRIPTION
When declaring parameters globally using the TunableParams dataclass, the parameters descriptions can be written in the docstring instead of the Field `description` argument, provided that the docstring is written between three double-quotes. This makes the parameter's description accessible by static code-checkers like Pylance, making it visible hovering over it in the IDE.
The original way of declaring parameters description (with the `description` argument of Fields) still works.