### PR TITLE
Fix names clashing between functions

### DIFF
--- a/examples/app_generate_schema.py
+++ b/examples/app_generate_schema.py
@@ -23,7 +23,7 @@ from tunablex.runtime import write_schema
 
 
 def main():
-    parser = argparse.ArgumentParser(prog="trace_generate_schema")
+    parser = argparse.ArgumentParser(prog="app_generate_schema")
     parser.add_argument(
         "--app",
         choices=["train", "serve"],

--- a/examples/myapp/params.py
+++ b/examples/myapp/params.py
@@ -45,6 +45,9 @@ class ModelParams(TunableParams):
     dropout: float = Field(0.2, ge=0.0, le=1.0, description="Dropout probability")
     agg: Literal["sum", "concat"] = Field("sum", description="Aggregation method")
 
+    same_name_arg: str = Field("same_name_arg_model")
+    """An arg that has the same name in two functions signatures"""
+
     Preprocess = PreprocessParams
     """Preprocess options nested under "model.preprocess"."""
 
@@ -54,6 +57,8 @@ class TrainParams(TunableParams):
 
     epochs: int = Field(10, ge=1, description="Number of training epochs")
     batch_size: int = Field(32, ge=1, description="Training batch size")
+    same_name_arg: str = Field("same_name_arg_train")
+    """An arg that has the same name in two functions signatures"""
 
 
 class ServeParams(TunableParams):

--- a/examples/myapp/pipeline_params.py
+++ b/examples/myapp/pipeline_params.py
@@ -29,17 +29,25 @@ def build_model(
     batch_norm: bool = True,
     root_param=MainParams.root_param,
     advanced_root_param=MainParams.Advanced.advanced_root_param,
+    same_name_arg=ModelParams.same_name_arg,
+    dummy_arg=TrainParams.epochs,  # used to test name conflicts
 ):
     """Build the model using centralized parameters."""
-    print("build_model", hidden_units, dropout, agg, batch_norm, root_param, advanced_root_param)
+    del dummy_arg
+    print("build_model", hidden_units, dropout, agg, batch_norm, root_param, advanced_root_param, same_name_arg)
     return "model"
 
 
-@tunable("epochs", "batch_size", apps="train")
+@tunable("epochs", "batch_size", "same_name_arg", apps="train")
 @tunable("optimizer", namespace="train", apps="train")
-def train(epochs=TrainParams.epochs, batch_size=TrainParams.batch_size, optimizer: Literal["adam", "sgd"] = "adam"):
+def train(
+    epochs=TrainParams.epochs,
+    batch_size=TrainParams.batch_size,
+    optimizer: Literal["adam", "sgd"] = "adam",
+    same_name_arg=TrainParams.same_name_arg,
+):
     """Train the model using centralized parameters."""
-    print("train", epochs, batch_size, optimizer)
+    print("train", epochs, batch_size, optimizer, same_name_arg)
 
 
 @tunable("nb_epochs", "other_batch_size", apps="train")

--- a/src/tunablex/decorators.py
+++ b/src/tunablex/decorators.py
@@ -169,9 +169,10 @@ def tunable(
 
     def decorator(fn):
         sig = inspect.signature(fn)
-        namespaces = set()
-        ref_names = {}
+        namespaces = {}
+        global_names = {}
         for name, p in sig.parameters.items():
+            global_name = name
             if name == "mro":
                 msg = "`mro` is a protected name, please use an other name for your tunable parameters."
                 raise ValueError(msg)
@@ -188,22 +189,21 @@ def tunable(
             default = p.default if p.default is not inspect._empty else ...
             if isinstance(default, TunableParamData):
                 # The parameter is declared in a TunableParam class; retrieve type, namespace and reference name
-                default, typ, ns, ref_name = (
+                default, typ, ns, global_name = (
                     default.value,
                     default.typ,
                     default.namespace,
                     default.name,
                 )
-                if ref_name != name:
-                    # Store the reference name for later look-up
-                    # This allows to have different local names for the same global parameter
-                    ref_names[name] = ref_name
-                    name = ref_name
             else:
                 typ = inspect.get_annotations(fn, eval_str=False)[name]
                 typ = eval(typ, fn.__globals__) if isinstance(typ, str) else typ
                 ns = namespace
-            namespaces.add(ns)
+            namespaces.setdefault(ns, []).append(name)
+            if global_name != name:
+                # Store the global name for later look-up (allows different local names for the same parameter)
+                global_names[name] = global_name
+                name = global_name
             REGISTRY.register(
                 TunableArg(
                     name=name,
@@ -216,33 +216,22 @@ def tunable(
             )
 
         @functools.wraps(fn)
-        def wrapper(*args, cfg: BaseModel | dict | None = None, **kwargs):
+        def wrapper(*args, **kwargs):
             # Handle static methods called from instances
             if isinstance(fn, staticmethod) and args[0].__class__.__name__ == fn.__qualname__.split(".")[0]:
                 args = args[1:]
-            if cfg is not None:
-                data = cfg if isinstance(cfg, dict) else cfg.model_dump()
-                filtered = {
-                    # Get the tunable arguments from the config and retrieve the original name
-                    k: data[ref_names.get(k, k)]
-                    for k in sig.parameters
-                    if ref_names.get(k, k) in data and k not in kwargs
-                }
-                return fn(*args, **filtered, **kwargs)
-
             cfg = _active_cfg.get()
             if cfg is not None:
                 filtered = {}
-                for ns in namespaces:
+                for ns, ns_vars in namespaces.items():
                     section = _resolve_nested_section(cfg, ns)
-                    if section is not None:
-                        data = section if isinstance(section, dict) else section.model_dump()
-                        filtered.update({
-                            # Get the tunable arguments from the config and retrieve the original name
-                            k: data[ref_names.get(k, k)]
-                            for k in sig.parameters
-                            if ref_names.get(k, k) in data and k not in kwargs
-                        })
+                    data = section if isinstance(section, dict) else section.model_dump()
+                    filtered.update({
+                        # Get the tunable arguments from the config and retrieve the original name
+                        k: data[global_names.get(k, k)]
+                        for k in ns_vars
+                        if global_names.get(k, k) in data and k not in kwargs
+                    })
                 return fn(*args, **filtered, **kwargs)
 
             return fn(*args, **kwargs)

--- a/tests/test_centralized_params.py
+++ b/tests/test_centralized_params.py
@@ -89,3 +89,26 @@ def test_get_description_from_docstring(tmp_path, run_example):
         cfg = json.load(f)
     assert "clip_outliers" in str(cfg)
     assert "Description in docstring." in str(cfg)
+
+
+def test_same_name_args(tmp_path, run_example):
+    cfg_path = tmp_path / "test_config"
+    run_example(
+        "examples/app_generate_schema.py",
+        ["--prefix", str(cfg_path)],
+    )
+    schema_path = cfg_path.with_suffix(".schema.json")
+    with schema_path.open() as f:
+        cfg = json.load(f)
+    # Check that both args appear in the config
+    assert "same_name_arg" in str(cfg["$defs"]["Model_Config"]["properties"])
+    assert "same_name_arg" in str(cfg["$defs"]["Train_Config"]["properties"])
+    # Check that the correct values are used during function call
+    code, out, err = run_example(
+        "examples/jsonargparse_app/train_jsonarg_params.py",
+        ["--config", str(schema_path)],
+    )
+    assert code == 0, err
+    print(out)
+    assert "build_model [128, 128] 0.2 sum True root advanced_root same_name_arg_model" in out
+    assert "train 10 32 adam same_name_arg_train" in out


### PR DESCRIPTION
In code such as:
```python
@tunable(apps="train")
def fn1(
    same_name_arg=Fn1Params.same_name_arg,
    other_arg=Fn2Params.other_arg,
):
    ...

@tunable(apps="train")
def fn2(same_name_arg=Fn2Params.same_name_arg):
    ....
```
`fn1` would sometimes receive the value of `Fn2Params.same_name_arg`, because args with the same name would be overwritten by tunablex wrapper during the call. This happened because the wrapper for `fn1` also looks into the `Fn2Params` namespace because of `other_arg`. This behaviour would appear randomly due to the non-deterministic ordering in Python `set`.

This PR fixes this behaviour by keeping a dictionary in the wrapper, saying from which namespace each arg should come from.
Also removed a way of passing a config to a function call that was never used (all practical applications uses the `use_config` context manager)